### PR TITLE
Check if proj init string is a unicode string

### DIFF
--- a/lib/pyproj/__init__.py
+++ b/lib/pyproj/__init__.py
@@ -320,8 +320,8 @@ class Proj(_proj.Proj):
                 raise RuntimeError('no projection control parameters specified')
             else:
                 projstring = _dict2string(kwargs)
-        elif type(projparams) == str:
-            # if projparams is a string, interpret as a proj4 init string.
+        elif type(projparams) == str or unicode:
+            # if projparams is a string or a unicode string, interpret as a proj4 init string.
             projstring = projparams
         else: # projparams a dict
             projstring = _dict2string(projparams)


### PR DESCRIPTION
In Python 2.7 "str" and "unicode" are two different type of objects.
If a unicode init string is provided to Proj object it will treat it as a dictionary and fail.
Checking for whether the string is a 'str' or 'unicode' type solves the problem.
